### PR TITLE
Remove (seemingly) unneeded is_email() check and wp_die() message

### DIFF
--- a/force-email-login.php
+++ b/force-email-login.php
@@ -21,8 +21,6 @@ public function plugins_loaded()
 {
     if (get_transient('force_email_login_lockdown') && isset($_POST['log'])) {
         wp_die('Please retry after a few seconds.');
-    } elseif (isset($_POST['log'], $_POST['pwd']) && !is_email($_POST['log'])) {
-        wp_die('Auth failed.');
     }
 
     remove_filter('authenticate', 'wp_authenticate_username_password', 20, 3);


### PR DESCRIPTION
Hi there -

Thanks for the great plugin! It's fast and easy, and works really smoothly.

I'm curious why you chose to check `is_email()` on line 24 in force-email-login.php, when that check is already being done in the `$this->authenticate()` method (line 45). Doing the check there and executing a `wp_die()` isn't a very user friendly option, because it gives the user no option to get back to the login page. The "Auth failed." error is harder for non-technical users to understand too.

If you remove the check, logins are still prevented when users try to login with a username. Further, instead of redirecting the user to a `wp_die()` page, they get redirected back to the login page, which will display a more helpful error message ("ERROR: Invalid username or incorrect password").

The pull request included here removes the unneeded check (lines 24 and 25). No further changes are necessary to display the error; WordPress handles that automatically.

Thanks again!
